### PR TITLE
Remove namespace from Program.fs

### DIFF
--- a/src/Falco.Template/Basic/Program.fs
+++ b/src/Falco.Template/Basic/Program.fs
@@ -1,5 +1,3 @@
-namespace AppName
-
 open Falco
 open Falco.Routing
 open Microsoft.AspNetCore.Builder


### PR DESCRIPTION
Closes #2.

Removes the namespace line from `Program.fs` in the Basic template so that a new program can compile.